### PR TITLE
added warning for halo mass function

### DIFF
--- a/yt_attic/halo_mass_function/halo_mass_function.py
+++ b/yt_attic/halo_mass_function/halo_mass_function.py
@@ -22,6 +22,7 @@ from yt.units.yt_array import \
     YTQuantity
 from yt.utilities.physical_ratios import \
     rho_crit_g_cm3_h2
+import warnings
 
 class HaloMassFcn():
     r"""
@@ -398,9 +399,9 @@ class HaloMassFcn():
             # All done!
 
     def dndm(self):
-        print 'Warning: The n_cumulative_analytic and dndM_dM_analytic functions are wrong'
-        print 'See https://github.com/yt-project/yt/issues/1228'
-        print 'and https://github.com/yt-project/yt/issues/1237'
+        warnings.warn('''Warning: The n_cumulative_analytic and dndM_dM_analytic functions are wrong')
+See https://github.com/yt-project/yt/issues/1228
+and https://github.com/yt-project/yt/issues/1237''')
         # constants - set these before calling any functions!
         # rho0 in units of h^2 Msolar/Mpc^3
         rho0 = YTQuantity(self.omega_matter0 * rho_crit_g_cm3_h2 * self.hubble0**2, 

--- a/yt_attic/halo_mass_function/halo_mass_function.py
+++ b/yt_attic/halo_mass_function/halo_mass_function.py
@@ -398,6 +398,9 @@ class HaloMassFcn():
             # All done!
 
     def dndm(self):
+        print 'Warning: The n_cumulative_analytic and dndM_dM_analytic functions are wrong'
+        print 'See https://github.com/yt-project/yt/issues/1228'
+        print 'and https://github.com/yt-project/yt/issues/1237'
         # constants - set these before calling any functions!
         # rho0 in units of h^2 Msolar/Mpc^3
         rho0 = YTQuantity(self.omega_matter0 * rho_crit_g_cm3_h2 * self.hubble0**2, 


### PR DESCRIPTION
I wasted too many days on this, now realising this functionality is not only disused, but broken. With this patch I am trying to save other people the same experience.
The dn/dm function likely has wrong h multiplication, and the cumulative one does not make sense at all when I plot it. Someone with better knowledge can hopefully fix it.

I found the first original version here, which has different h multiplication and may be correct:
https://raw.githubusercontent.com/yt-project/yt/49f9354083b407b974529a492a4dafe3a03adc17/yt/extensions/HaloMassFcn.py

More discussion at  https://github.com/yt-project/yt/issues/1228
and https://github.com/yt-project/yt/issues/1237

