### PR TITLE
remove six dependency from sfr_spectrum

### DIFF
--- a/yt_attic/star_analysis/sfr_spectrum.py
+++ b/yt_attic/star_analysis/sfr_spectrum.py
@@ -20,7 +20,6 @@ from yt.utilities.on_demand_imports import _h5py as h5py
 import math
 
 from yt.config import ytcfg
-from yt.extern.six.moves import zip as izip
 from yt.funcs import \
     get_pbar
 from yt.units import \
@@ -524,7 +523,7 @@ class SpectrumBuilder(object):
 
         # Interpolate the flux for each star, adding to the total by weight.
         pbar = get_pbar("Calculating fluxes", len(self.star_mass))
-        for i, star in enumerate(izip(Mname, Aindex, ratio1, ratio2,
+        for i, star in enumerate(zip(Mname, Aindex, ratio1, ratio2,
                                       self.star_mass)):
             # Pick the right age bin for the right flux array.
             flux = self.flux[star[0]][star[1], :]


### PR DESCRIPTION
Was helping out someone on slack who was trying to use the `StarFormationRate` functionality, this PR just fixes the import error that comes from having the `six` compatibility layer. I can't speak to whether or not the remainder of the code functions as intended, but this pr does fix the import error. 